### PR TITLE
add '/usr/lib64/' in qt4 search path for fedora24 x64

### DIFF
--- a/qt4.lisp
+++ b/qt4.lisp
@@ -61,6 +61,7 @@
                           #+linux #p"/usr/lib/"
                           #+linux #p"/usr/local/lib/"
                           #+linux #p"/usr/lib64/qt48/"
+                          #+linux #p"/usr/lib64/"
                           #+linux #p"/usr/lib/*/"
                           #+osx-ports #p"/opt/local/lib/"
                           #+osx-ports #p"/opt/local/libexec/qt4/lib/"


### PR DESCRIPTION
I found in my fedora24(`4.6.3-300.fc24.x86_64`), `qtCore` is in `/usr/lib64/`.

and `(find-qt-lib-directory)` does not search for that path.

so I add this path and everything works out just fine. 

And thanks for this great job for easing the pain :)