### PR TITLE
Replace QT-LIBS::SETENV with (SETF UIOP:GETENV) for portability

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -190,22 +190,14 @@
              ~&Got      ~a"
               file (checksum-string checksum) (checksum-string received)))))
 
-(defun setenv (envvar new-value)
-  #+sbcl (sb-posix:setenv envvar new-value 1)
-  #+ccl (ccl:setenv envvar new-value T)
-  #+ecl (ext:setenv envvar new-value)
-  #-(or sbcl ccl ecl) (warn "Don't know how to perform SETENV.~
-                           ~&Please set the environment variable ~s to ~s to ensure proper operation."
-                            envvar new-value)
-  new-value)
-
 (defun get-path (&optional (envvar "PATH"))
   (cl-ppcre:split #+windows ";+" #-windows ":+" (uiop:getenv envvar)))
 
 (defun set-path (paths &optional (envvar "PATH"))
-  (setenv envvar (etypecase paths
-                   (string paths)
-                   (list (format NIL (load-time-value (format NIL "~~{~~a~~^~a~~}" #+windows ";" #-windows ":")) paths)))))
+  (setf (uiop:getenv envvar)
+        (etypecase paths
+          (string paths)
+          (list (format NIL (load-time-value (format NIL "~~{~~a~~^~a~~}" #+windows ";" #-windows ":")) paths)))))
 
 (defun pushnew-path (path &optional (envvar "PATH"))
   (let ((path (etypecase path


### PR DESCRIPTION
In particular, this makes qt-libs work on Allegro CL.